### PR TITLE
fix: Scrollbar always displayed in Key connection view

### DIFF
--- a/src/views/Connect/Connect.css
+++ b/src/views/Connect/Connect.css
@@ -24,5 +24,5 @@
 .results {
   display: grid;
   max-height: 220px;
-  overflow-y: scroll;
+  overflow-y: auto;
 }


### PR DESCRIPTION
### Before
![image](https://user-images.githubusercontent.com/10096404/223463246-c18e8397-fe60-49cc-8090-06a3874e3f19.png)

### After
![image](https://user-images.githubusercontent.com/10096404/223463350-4b4967c9-fc7d-4d29-825d-51757ccd7310.png)
