### PR TITLE
fix: Checking token scope

### DIFF
--- a/src/views/Settings/Settings.tsx
+++ b/src/views/Settings/Settings.tsx
@@ -57,7 +57,11 @@ export const Settings: FunctionComponent<Props> = ({ noNavigation }) => {
   const validateTolgeeCredentials = async () => {
     try {
       const res = await mutateAsync({});
-      if (res && res.scopes?.includes("translations.view")) {
+      if (
+        res &&
+        res.scopes?.includes("translations.view") &&
+        res.scopes?.includes("translations.edit")
+      ) {
         return true;
       }
       throw new Error(


### PR DESCRIPTION
The plugin didn't check for `translations.edit` scope in the provided token even though it was throwing the following error:
`Missing token scopes. The token should have translations.view and translations.edit scopes.`