### PR TITLE
feat: Use node text when searching for key to connect to

### DIFF
--- a/src/views/Connect/Connect.tsx
+++ b/src/views/Connect/Connect.tsx
@@ -29,7 +29,7 @@ export const Connect = ({ node }: Props) => {
 
   const language = useGlobalState((c) => c.config?.language);
 
-  const [search, setSearch] = useState(node.key || "");
+  const [search, setSearch] = useState(node.key || node.characters);
 
   const [debouncedSearch] = useDebounce(search, 1000);
 


### PR DESCRIPTION
This PR changes the behavior so that when user clicks on `Connect to existing key` and they didn't specify a key name, the plugin will use the node text when searching for keys.