### PR TITLE
fix: add figma sdk type to headers

### DIFF
--- a/src/ui/client/client.ts
+++ b/src/ui/client/client.ts
@@ -73,6 +73,7 @@ async function customFetch(
   init.headers = init.headers || {};
   init.headers = {
     "X-API-Key": options.apiKey,
+    "X-Tolgee-SDK-Type": "Figma",
     ...init.headers,
   };
 


### PR DESCRIPTION
Closing #17 (I'm not including the SDK version, since figma handles versioning on its own)