### PR TITLE
Add setting to auto-generate key base on node name

### DIFF
--- a/src/main/utils/settingsTools.ts
+++ b/src/main/utils/settingsTools.ts
@@ -76,8 +76,15 @@ export const setPluginData = async (data: Partial<TolgeeConfig>) => {
     namespacesDisabled,
     ignorePrefix,
     ignoreNumbers,
+    useNameAsDefaultKey,
   } = data;
-  await setGlobalSettings({ apiKey, apiUrl, ignorePrefix, ignoreNumbers });
+  await setGlobalSettings({
+    apiKey,
+    apiUrl,
+    ignorePrefix,
+    ignoreNumbers,
+    useNameAsDefaultKey,
+  });
   setDocumentData({
     apiKey,
     apiUrl,
@@ -85,6 +92,7 @@ export const setPluginData = async (data: Partial<TolgeeConfig>) => {
     namespacesDisabled,
     ignorePrefix,
     ignoreNumbers,
+    useNameAsDefaultKey,
     documentInfo: true,
   });
   setPageData({ language, pageInfo: true });

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,7 @@ export type GlobalSettings = {
   apiKey: string;
   ignorePrefix: string;
   ignoreNumbers: boolean;
+  useNameAsDefaultKey: boolean;
 };
 
 export type CurrentDocumentSettings = GlobalSettings & {

--- a/src/ui/views/Index/Index.tsx
+++ b/src/ui/views/Index/Index.tsx
@@ -40,6 +40,9 @@ export const Index = () => {
   const namespacesDisabled = useGlobalState(
     (c) => c.config?.namespacesDisabled
   );
+  const useNameAsDefaultKey = useGlobalState(
+    (c) => c.config?.useNameAsDefaultKey
+  );
 
   const languagesLoadable = useApiQuery({
     url: "/v2/projects/languages",
@@ -226,7 +229,9 @@ export const Index = () => {
           keyComponent={(node) =>
             !node.connected && (
               <KeyInput
-                initialValue={node.key || ""}
+                initialValue={
+                  node.key || (useNameAsDefaultKey ? node.name : "")
+                }
                 onDebouncedChange={handleKeyChange(node)}
               />
             )

--- a/src/ui/views/Settings/ProjectSettings.tsx
+++ b/src/ui/views/Settings/ProjectSettings.tsx
@@ -83,6 +83,7 @@ export const ProjectSettings: FunctionComponent<Props> = ({
           initialData?.namespacesDisabled ?? namespacesNotPresent,
         ignoreNumbers: initialData?.ignoreNumbers ?? true,
         ignorePrefix: initialData?.ignorePrefix ?? "_",
+        useNameAsDefaultKey: initialData?.useNameAsDefaultKey ?? false,
       });
     }
   }, [languages, namespaces]);
@@ -177,6 +178,18 @@ export const ProjectSettings: FunctionComponent<Props> = ({
         }
       >
         <Text>Ignore nodes with numbers</Text>
+      </Checkbox>
+      <VerticalSpace space="small" />
+      <Checkbox
+        value={Boolean(settings?.useNameAsDefaultKey)}
+        onChange={(e) =>
+          setSettings((settings) => ({
+            ...settings!,
+            useNameAsDefaultKey: Boolean(e.currentTarget.checked),
+          }))
+        }
+      >
+        <Text>Use node name as key</Text>
       </Checkbox>
     </Fragment>
   );


### PR DESCRIPTION
Our TEXT nodes already have the string key as the Node name, so I added the option to prefill the text field with the name of the selected node if no key has been defined for it