### PR TITLE
Figma plugin is limited to loading the first 20 languages

### DIFF
--- a/src/ui/views/Index/Index.tsx
+++ b/src/ui/views/Index/Index.tsx
@@ -42,6 +42,9 @@ export const Index = () => {
   const languagesLoadable = useApiQuery({
     url: "/v2/projects/languages",
     method: "get",
+    query: {
+      size: 1000,
+    },
   });
 
   const namespacesLoadable = useApiQuery({

--- a/src/ui/views/PageSetup/PageSetup.tsx
+++ b/src/ui/views/PageSetup/PageSetup.tsx
@@ -30,6 +30,9 @@ export const PageSetup: FunctionComponent = () => {
   const languagesLoadable = useApiQuery({
     url: "/v2/projects/languages",
     method: "get",
+    query: {
+      size: 1000
+    },
     options: {
       cacheTime: 0,
       staleTime: 0,

--- a/src/ui/views/Settings/ProjectSettings.tsx
+++ b/src/ui/views/Settings/ProjectSettings.tsx
@@ -33,6 +33,9 @@ export const ProjectSettings: FunctionComponent<Props> = ({
   const languagesLoadable = useApiQuery({
     url: "/v2/projects/languages",
     method: "get",
+    query: {
+      size: 1000,
+    },
     options: {
       cacheTime: 0,
       staleTime: 0,


### PR DESCRIPTION
This pull request updates API queries in three components to include a query parameter with a size of 1000. This adjustment ensures that the API explicitly requests a larger dataset, accommodating up to 1000 items per query. While not an ideal solution, it provides a pragmatic improvement to ensure consistent data retrieval across the affected components.

Updates to API queries:

* [`src/ui/views/Index/Index.tsx`](diffhunk://#diff-9bb03b3c905bb7a3993f8154f1a86b9f1956715cfb25205f29799f8228170a0eR45-R47): Added a `query` parameter with `size: 1000` to the `languagesLoadable` API query.
* [`src/ui/views/PageSetup/PageSetup.tsx`](diffhunk://#diff-d488e08045386aa029429e8f597571d0168f6093905ce07b6eaa3476ae321dd8R33-R35): Added a `query` parameter with `size: 1000` to the `languagesLoadable` API query.
* [`src/ui/views/Settings/ProjectSettings.tsx`](diffhunk://#diff-54bc8b679cf38001e3554888a0d4fdf0ee4e006dff7558e38605a87be17dfc8cR36-R38): Added a `query` parameter with `size: 1000` to the `languagesLoadable` API query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased the number of languages retrieved from the project languages list, allowing up to 1000 entries to be displayed in relevant sections.
- **Bug Fixes**
  - Improved consistency and completeness of language lists across various pages by fetching a larger set of languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->