### PR TITLE
fix: add error handling for invalid api keys and other errors

### DIFF
--- a/src/main/endpoints/notify.ts
+++ b/src/main/endpoints/notify.ts
@@ -1,0 +1,5 @@
+import { createEndpoint } from "../utils/createEndpoint";
+
+export const notifyEndpoint = createEndpoint<string, void>("NOTIFY", (arg) => {
+  figma.notify(arg);
+});

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -28,7 +28,7 @@ import { cleanUp, highlightNodeEndpoint } from "./endpoints/highlightNode";
 import { DEFAULT_SIZE } from "@/ui/state/sizes";
 import { formatTextEndpoint } from "./endpoints/formatText";
 import { editorTypeEndpoint } from "./endpoints/editorType";
-import { notifyEndpoint } from './endpoints/notify';
+import { notifyEndpoint } from "./endpoints/notify";
 
 const getAllPages = () => {
   const document = figma.root;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -28,6 +28,7 @@ import { cleanUp, highlightNodeEndpoint } from "./endpoints/highlightNode";
 import { DEFAULT_SIZE } from "@/ui/state/sizes";
 import { formatTextEndpoint } from "./endpoints/formatText";
 import { editorTypeEndpoint } from "./endpoints/editorType";
+import { notifyEndpoint } from './endpoints/notify';
 
 const getAllPages = () => {
   const document = figma.root;
@@ -105,6 +106,7 @@ export default async function () {
   setNodesDataEndpoint.register();
   highlightNodeEndpoint.register();
   editorTypeEndpoint.register();
+  notifyEndpoint.register();
 
   const config = await getPluginData();
 

--- a/src/ui/hooks/useAllTranslations.ts
+++ b/src/ui/hooks/useAllTranslations.ts
@@ -2,6 +2,7 @@ import { useState } from "preact/hooks";
 import { useApiMutation } from "../client/useQueryApi";
 import { components } from "../client/apiSchema.generated";
 import { TranslationData } from "../client/types";
+import { useFigmaNotify } from "./useFigmaNotify";
 
 type Props = {
   language: string;
@@ -21,6 +22,8 @@ export const useAllTranslations = () => {
     url: "/v2/projects/translations",
     method: "get",
   });
+
+  const notifier = useFigmaNotify();
 
   const [translationsData, setTranslationsData] =
     useState<TranslationData | null>(null);
@@ -79,6 +82,12 @@ export const useAllTranslations = () => {
       setIsLoading(true);
       try {
         return await loadData(props);
+      } catch (e) {
+        if (e === "invalid_project_api_key") {
+          notifier.mutate("Invalid project API key");
+        }
+
+        throw e;
       } finally {
         setIsLoading(false);
       }

--- a/src/ui/hooks/useFigmaNotify.ts
+++ b/src/ui/hooks/useFigmaNotify.ts
@@ -1,0 +1,12 @@
+import { useMutation } from "react-query";
+import { notifyEndpoint } from "../../main/endpoints/notify";
+import { delayed } from "../../main/utils/delayed";
+
+export const useFigmaNotify = () => {
+  const result = useMutation<void, unknown, string>(
+    [notifyEndpoint.name],
+    delayed((props: string) => notifyEndpoint.call(props))
+  );
+
+  return { ...result };
+};

--- a/src/ui/hooks/useTranslation.ts
+++ b/src/ui/hooks/useTranslation.ts
@@ -1,3 +1,4 @@
+import { useState } from "preact/hooks";
 import { useAllTranslations } from "./useAllTranslations";
 
 type Props = {
@@ -9,15 +10,22 @@ type Props = {
 
 export const useTranslation = (props: Props) => {
   const translationsLoadable = useAllTranslations();
+  const [error, setError] = useState<any | null>(null);
 
   if (
     !translationsLoadable.isLoading &&
-    translationsLoadable.translationsData == null
+    translationsLoadable.translationsData == null &&
+    translationsLoadable.error == null &&
+    error == null
   ) {
-    translationsLoadable.getData({
-      language: props.language,
-      namespaces: [props.namespace ?? "default"],
-    });
+    translationsLoadable
+      .getData({
+        language: props.language,
+        namespaces: [props.namespace ?? "default"],
+      })
+      .catch((e) => {
+        setError(e);
+      });
   }
 
   return {
@@ -29,6 +37,6 @@ export const useTranslation = (props: Props) => {
           ]?.[props.key] ?? null
         : null,
     isLoading: translationsLoadable.isLoading,
-    error: translationsLoadable.error,
+    error,
   };
 };

--- a/src/ui/views/Pull/Pull.tsx
+++ b/src/ui/views/Pull/Pull.tsx
@@ -2,9 +2,11 @@ import { Fragment, FunctionalComponent, h } from "preact";
 import { useEffect, useState } from "preact/hooks";
 import clsx from "clsx";
 import {
+  Banner,
   Button,
   Container,
   Divider,
+  IconWarning32,
   VerticalSpace,
 } from "@create-figma-plugin/ui";
 
@@ -36,13 +38,24 @@ export const Pull: FunctionalComponent<Props> = ({ lang }) => {
   const allTranslationsLoadable = useAllTranslations();
   const [diffData, setDiffData] = useState<ReturnType<typeof getPullChanges>>();
 
+  const [error, setError] = useState<string>();
+
   async function computeDiff() {
-    const translations = await allTranslationsLoadable.getData({
-      language: lang ?? "",
-    });
-    setDiffData(
-      getPullChanges(selectedNodes.data?.items || [], lang, translations)
-    );
+    try {
+      const translations = await allTranslationsLoadable.getData({
+        language: lang ?? "",
+      });
+      setDiffData(
+        getPullChanges(selectedNodes.data?.items || [], lang, translations)
+      );
+      setError(undefined);
+    } catch (e) {
+      if (e === "invalid_project_api_key") {
+        setError("Invalid project API key");
+      } else {
+        setError(`Cannot get translation data. ${e}`);
+      }
+    }
   }
 
   useEffect(() => {
@@ -135,7 +148,9 @@ export const Pull: FunctionalComponent<Props> = ({ lang }) => {
       <Divider />
       <VerticalSpace space="large" />
       <Container space="medium">
-        {isLoading || !diffData ? (
+        {error ? (
+          <Banner icon={<IconWarning32 />}>{error}</Banner>
+        ) : isLoading || !diffData ? (
           <FullPageLoading text="Searching document for translations" />
         ) : allTranslationsLoadable.error ? (
           <Fragment>

--- a/src/ui/views/Push/Push.tsx
+++ b/src/ui/views/Push/Push.tsx
@@ -38,6 +38,7 @@ export const Push: FunctionalComponent = () => {
   const language = useGlobalState((c) => c.config!.language!);
   const { setRoute } = useGlobalActions();
   const [error, setError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string>();
   const [success, setSuccess] = useState(false);
   const [_loadingStatus, setLoadingStatus] = useState<string | undefined>();
   const [changes, setChanges] = useState<KeyChanges>();
@@ -74,6 +75,12 @@ export const Push: FunctionalComponent = () => {
       setChanges(
         getPushChanges(deduplicatedNodes, translations, language, screenshots)
       );
+    } catch (e) {
+      if (e === "invalid_project_api_key") {
+        setErrorMessage("Invalid API key");
+      } else {
+        setErrorMessage(`Cannot get translation data. ${e}`);
+      }
     } finally {
       setLoadingStatus(undefined);
     }
@@ -249,6 +256,11 @@ export const Push: FunctionalComponent = () => {
       setSuccess(true);
     } catch (e) {
       setError(true);
+      if (e === "invalid_project_api_key") {
+        setErrorMessage("Invalid project API key");
+      } else {
+        setErrorMessage(`Cannot get translation data. ${e}`);
+      }
       console.error(e);
     } finally {
       setLoadingStatus(undefined);
@@ -283,13 +295,16 @@ export const Push: FunctionalComponent = () => {
       <Divider />
       <VerticalSpace space="large" />
       <Container space="medium">
-        {isLoading || !changes ? (
+        {errorMessage && !error ? (
+          <Banner icon={<IconWarning32 />}>{errorMessage}</Banner>
+        ) : isLoading || !changes ? (
           <FullPageLoading text={loadingStatus} />
         ) : error ? (
           <Fragment>
             <div>
               <Banner icon={<IconWarning32 />}>
-                {updateTranslations.error ||
+                {errorMessage ||
+                  updateTranslations.error ||
                   "An error has occurred during push."}
               </Banner>
             </div>

--- a/src/ui/views/Settings/Settings.tsx
+++ b/src/ui/views/Settings/Settings.tsx
@@ -85,7 +85,11 @@ export const Settings: FunctionComponent<Props> = ({ noNavigation }) => {
       await validateTolgeeCredentials();
       setValidated(true);
     } catch (e: any) {
-      setError(e.message || e);
+      setError(
+        (e === "invalid_project_api_key"
+          ? "Invalid project API key"
+          : e.message) || e
+      );
     }
   };
 
@@ -100,7 +104,11 @@ export const Settings: FunctionComponent<Props> = ({ noNavigation }) => {
       setConfig(tolgeeConfig);
       setRoute("index");
     } catch (e: any) {
-      setError(e.message || e);
+      setError(
+        (e === "invalid_project_api_key"
+          ? "Invalid project API key"
+          : e.message) || e
+      );
     }
     queryClient.clear();
   };


### PR DESCRIPTION
The plugin got stuck in some screens and was infinitely trying to load translations when in string details.

This pr adds a basic error handling to the plugin giving the user a hint why his action failed and stops trying to load the translation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added in-app notifications for displaying messages within the Figma environment.
  - Introduced a new notification hook for triggering notifications from the user interface.

- **Bug Fixes**
  - Improved error handling and user feedback for invalid project API keys across multiple views.
  - Enhanced error messages and banners for translation-related actions, providing clearer information when issues occur.

- **User Interface**
  - Updated error banners to display specific error messages and icons when translation or API key errors are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->