### PR TITLE
adjust logic for formatting the text

### DIFF
--- a/src/main/endpoints/formatText.ts
+++ b/src/main/endpoints/formatText.ts
@@ -95,7 +95,7 @@ export const formatText = async ({
           await figma.loadFontAsync({ family, style });
           return style;
         } catch (error) {
-          continue;
+          console.log(`Failed to load font: ${error}`);
         }
       }
     }
@@ -143,7 +143,7 @@ export const formatText = async ({
           await figma.loadFontAsync({ family, style });
           return style;
         } catch (error) {
-          continue;
+          console.error(`Failed to load font: ${error}`);
         }
       }
     }
@@ -197,8 +197,8 @@ export const formatText = async ({
 
   const getFontForRange = (range: { start: number; end: number }) => {
     const font = textNode.getRangeFontName(
-      defaultRanges[0].start,
-      Math.min(textNode.characters.length, defaultRanges[0].end)
+      range.start,
+      Math.min(textNode.characters.length, range.end)
     );
 
     if (font === figma.mixed) {

--- a/src/main/endpoints/formatText.ts
+++ b/src/main/endpoints/formatText.ts
@@ -195,6 +195,21 @@ export const formatText = async ({
     }
   };
 
+  const getFontForRange = (range: { start: number; end: number }) => {
+    const font = textNode.getRangeFontName(
+      defaultRanges[0].start,
+      Math.min(textNode.characters.length, defaultRanges[0].end)
+    );
+
+    if (font === figma.mixed) {
+      return textNode.getRangeFontName(
+        range.start,
+        range.start + 1
+      ) as FontName;
+    }
+    return font as FontName;
+  };
+
   const boldRanges = [
     ...findRanges(formattedWithoutBreaks, "strong"),
     ...findRanges(formattedWithoutBreaks, "b"),
@@ -232,28 +247,23 @@ export const formatText = async ({
     defaultRanges.push(currentRange);
   }
 
-  if (defaultRanges.length > 0) {
-    const font = textNode.getRangeFontName(
-      defaultRanges[0].start,
-      defaultRanges[0].end
-    ) as FontName;
+  for (const range of defaultRanges) {
+    const font = getFontForRange(range);
 
     if (font.family) {
       await figma.loadFontAsync({
         family: font.family,
         style: font.style,
       });
-      await applyStyles(defaultRanges, {
+      await applyStyles([range], {
         family: font.family,
         style: font.style,
       });
     }
   }
+
   for (const range of boldRanges) {
-    const font = textNode.getRangeFontName(
-      range.start,
-      Math.min(textNode.characters.length, range.end)
-    ) as FontName;
+    const font = getFontForRange(range);
 
     if (font.family) {
       const availableFonts = await getFontsOfFamily(font);
@@ -270,10 +280,7 @@ export const formatText = async ({
   }
 
   for (const range of italicRanges) {
-    const font = textNode.getRangeFontName(
-      range.start,
-      Math.min(textNode.characters.length, range.end)
-    ) as FontName;
+    const font = getFontForRange(range);
 
     if (font.family) {
       const availableFonts = await getFontsOfFamily(font);


### PR DESCRIPTION
There was a problem with translating the text when a local font was applied to the text, because we relied on commonly used, but not normed, font weight names.

With this pr we use the previous applied font where possible, and if we detect bold or italic tags in the string, we use the same fontname as before, try to find the best matching font-weight variation and use that or the default if none was found.

Should fix the issue with missing fonts preventing the translation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved font style accuracy by dynamically detecting and loading the best matching bold and italic fonts for each text range.
- **Bug Fixes**
	- Enhanced handling of mixed font styles within text, ensuring correct application of bold and italic formatting.
- **Refactor**
	- Updated internal logic for applying text formatting to use dynamic font style resolution and loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->