### PR TITLE
fix: never persist apiKey in shared document storage

### DIFF
--- a/src/main/utils/settingsTools.ts
+++ b/src/main/utils/settingsTools.ts
@@ -36,19 +36,33 @@ export const deleteGlobalSettings = async () => {
 
 export const getDocumentData = (): Partial<CurrentDocumentSettings> => {
   const pluginData = figma.root.getPluginData(TOLGEE_PLUGIN_CONFIG_NAME);
-  const result = pluginData
-    ? (JSON.parse(pluginData) as Partial<CurrentDocumentSettings>)
+  // Parse into a loose record first so the self-heal can strip a field the
+  // declared type no longer admits, then narrow on return.
+  const stored = pluginData
+    ? (JSON.parse(pluginData) as Record<string, unknown>)
     : {};
+
+  // Self-heal: older versions persisted the apiKey into the shared document.
+  // Drop it so a leaked key can never override the per-user key from
+  // clientStorage (and so it stops being surfaced to other collaborators).
+  delete stored.apiKey;
 
   return {
     ignorePrefix: "_",
     ignoreNumbers: true,
-    ...result,
+    ...(stored as Partial<CurrentDocumentSettings>),
   };
 };
 
 const setDocumentData = (data: Partial<CurrentDocumentSettings>) => {
-  figma.root.setPluginData(TOLGEE_PLUGIN_CONFIG_NAME, JSON.stringify(data));
+  // Defense in depth: never write the apiKey into the shared document, even if
+  // a caller bypasses the type. The secret belongs in clientStorage only.
+  const documentData = { ...data };
+  delete (documentData as { apiKey?: string }).apiKey;
+  figma.root.setPluginData(
+    TOLGEE_PLUGIN_CONFIG_NAME,
+    JSON.stringify(documentData),
+  );
 };
 
 export const deleteDocumentData = () => {
@@ -93,10 +107,10 @@ export const setPluginData = async (data: Partial<TolgeeConfig>) => {
     updateScreenshots,
     variableCasing,
   } = data;
+  // apiKey -> per-user clientStorage only (never the shared document).
   await setGlobalSettings({ apiKey, apiUrl, ignorePrefix, ignoreNumbers });
   setDocumentData({
     addTags,
-    apiKey,
     apiUrl,
     branch,
     documentInfo: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,7 +130,12 @@ export type GlobalSettings = {
     | "noSpaces";
 };
 
-export type CurrentDocumentSettings = GlobalSettings & {
+// NOTE: `apiKey` is intentionally omitted. The API key is a secret and must
+// never be persisted in the shared document (figma.root pluginData), which is
+// stored in plaintext in the .fig file, syncs to every collaborator and travels
+// with file copies/exports. The key lives in figma.clientStorage (per-user)
+// only — see settingsTools.ts.
+export type CurrentDocumentSettings = Omit<GlobalSettings, "apiKey"> & {
   namespace: string;
   branch?: string;
   documentInfo: true;
@@ -144,7 +149,11 @@ export type CurrentPageSettings = {
   nodeInfo?: NodeInfo;
 };
 
-export type TolgeeConfig = CurrentDocumentSettings & CurrentPageSettings;
+// The full in-memory config the UI works with. `apiKey` comes from the
+// per-user clientStorage layer, the rest from the document/page layers.
+export type TolgeeConfig = Pick<GlobalSettings, "apiKey"> &
+  CurrentDocumentSettings &
+  CurrentPageSettings;
 
 export type FormattedNode = {
   characters: string;

--- a/src/ui/views/Router.tsx
+++ b/src/ui/views/Router.tsx
@@ -64,6 +64,7 @@ export const Router = () => {
   const routeKey = useGlobalState((c) => c.routeKey);
   const globalError = useGlobalState((c) => c.globalError);
   const documentInfo = useGlobalState((c) => c.config?.documentInfo);
+  const apiKey = useGlobalState((c) => c.config?.apiKey);
   const pageInfo = useGlobalState((c) => c.config?.pageInfo);
   const pageCopy = useGlobalState((c) => c.config?.pageCopy);
   const pageStringDetails = useGlobalState((c) => c.config?.pageStringDetails);
@@ -71,7 +72,11 @@ export const Router = () => {
   const { setRoute } = useGlobalActions();
   const editorMode = useEditorMode();
 
-  const forceSettings = !pageCopy && !documentInfo;
+  // The apiKey now lives in per-user clientStorage, not the shared document, so
+  // a collaborator can open a configured file (documentInfo is set) yet have no
+  // key of their own. Force them into Settings to enter one instead of dropping
+  // them on a non-working Index.
+  const forceSettings = !pageCopy && (!documentInfo || !apiKey);
   const errorOnTop = !forceSettings && routeKey !== "settings";
 
   const handleResolveError = () => {


### PR DESCRIPTION
## Problem

The plugin persists the Tolgee **API key into the shared Figma document** (`figma.root` pluginData), not just into per-user `figma.clientStorage`.

`setPluginData` writes the key to both stores, and `getPluginData` merges document settings *over* clientStorage:

```ts
return {
  ...(await getGlobalSettings()), // per-user clientStorage
  ...getDocumentData(),           // shared document — overrides the above
  ...getPageData(),
};
```

`figma.root` pluginData is stored in the `.fig` file, syncs to every collaborator and travels with file copies/exports. The practical effect for a multi-user setup:

- The **last person to enter a key writes it into the document**, and it becomes the effective key for *everyone* opening that file — their own per-user key is overridden.
- Changing the key changes it for all collaborators.
- The key is readable by anyone with access to the file (and ends up in exported `.fig` files in plaintext).

This is the root cause behind the symptoms in #50 ("API key is getting forgotten" — the document copy clobbers the per-user one), and it contributes to the oversized document pluginData flagged by Figma in #56.

## Fix

Keep the API key in per-user `clientStorage` only — the secret never touches the shared document:

- **types**: `CurrentDocumentSettings` now `Omit`s `apiKey`; `TolgeeConfig` `Pick`s it back from `GlobalSettings` so the UI is unchanged.
- **`setDocumentData`**: strips `apiKey` before writing (defense in depth).
- **`getDocumentData`**: strips `apiKey` on read, so a key already leaked into an existing document can no longer override the per-user key or be surfaced to other collaborators (self-heal).
- **routing**: because the key is now per-user, a collaborator can open an already-configured file (`documentInfo` is set in the document) while having no key of their own. `Router` previously gated the setup screen on `documentInfo` alone, dropping such a user on a non-working Index. It now forces the Settings view when `apiKey` is missing.

`apiUrl` / `namespace` / `branch` intentionally **stay** document-scoped — they are connection/mapping info, not secrets, and sharing them keeps file setup low-friction.

## Notes

- **Existing files**: the self-heal removes the leaked key from what the plugin reads and rewrites, but a key already written into a distributed/exported `.fig` stays at rest in that file until a settings re-save. Any key that was ever stored in a document should be **rotated**. (An active one-time scrub on init could be a follow-up.)
- **Follow-up (not in this PR)**: `apiUrl` / `ignorePrefix` / `ignoreNumbers` are currently written to *both* stores with the document winning, leaving stale clientStorage copies — worth consolidating to one home per field (relates to #56). Happy to open a separate PR.
- **Tests**: the repo has no unit tests around `settingsTools` (jest is a devDependency but unconfigured; Cypress covers the web harness, which doesn't reach these functions). The key invariants worth guarding if you'd like a test setup added: (1) `setDocumentData` never writes `apiKey`; (2) `getDocumentData` strips a leaked `apiKey`; (3) `getPluginData` still returns the `apiKey` from clientStorage. Glad to add these if you point me at a preferred test approach.

Verified locally: `npm run build` (typecheck + minify) and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security issue where API keys could be shared with collaborators on shared documents. API keys are now stored securely as per-user settings and never written to shared document data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->