### PR TITLE
fix: derive {component} key placeholder from instances

### DIFF
--- a/src/main/utils/nodeParents.ts
+++ b/src/main/utils/nodeParents.ts
@@ -35,6 +35,17 @@ export function getAllParents(nodeId: string): NodeParents {
       !result.component
     ) {
       result.component = parent;
+    } else if (parent.type === "INSTANCE" && !result.component) {
+      // For an instance, resolve the main component it was created from.
+      // If that component is a variant inside a component set, use the set
+      // so the key gets the recognizable component name (e.g. "Button").
+      const mainComponent = parent.mainComponent;
+      if (mainComponent) {
+        result.component =
+          mainComponent.parent?.type === "COMPONENT_SET"
+            ? (mainComponent.parent as ComponentSetNode)
+            : mainComponent;
+      }
     } else if (parent.type === "SECTION" && !result.section) {
       result.section = parent;
     } else if (parent.type === "GROUP" && !result.group) {


### PR DESCRIPTION
## Problem

When generating a key for a text node that lives inside a **component instance**, the `{component}` placeholder was left empty. Keys came out missing the component name — e.g. `-log-in` instead of `component-log-in`. A customer reported this.

The cause: `getAllParents` only matched parents of type `COMPONENT` / `COMPONENT_SET`. An instance node has type `INSTANCE`, so the component parent was never found for instances.

## Fix

When an `INSTANCE` parent is encountered while walking the node hierarchy, resolve its main component and use its name. If the main component is a variant inside a component set, the set name is used so the key gets the recognizable component name.

- Single, minimal change in `src/main/utils/nodeParents.ts`.
- No new traversal and no async — `mainComponent` is read synchronously, consistent with the existing synchronous `figma.getNodeById` usage. No measurable performance impact.
- Existing behavior for real components, frames, sections and groups is untouched.

## Note

This uses the synchronous `mainComponent` getter, which matches the plugin's current (non `dynamic-page`) document access mode. If the plugin ever switches to `documentAccess: "dynamic-page"`, this and the existing `figma.getNodeById` call would both need to move to their async equivalents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parent resolution so components nested through instances are now recognized correctly.
  * Component-related actions and navigation should work more reliably in instance-based structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->